### PR TITLE
chore(deps): update CodeQL action v4 pin

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -42,12 +42,12 @@ jobs:
           cache-dependency-path: go.sum
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@fddeee1a7ece751b577e409a89057319e3172939 # v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
 
       - name: Analyze
-        uses: github/codeql-action/analyze@fddeee1a7ece751b577e409a89057319e3172939 # v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Updates both CodeQL init and analyze actions atomically to the current verified v4 tag commit cdf488f595d80d6e07e03d4674febd5ab45fa938. This supersedes #4 and #5, which split the two pins across separate PRs. Local verify and process smoke passed. CodeQL itself remains intentionally skipped while this personal repository is private.