### PR TITLE
ci: migrate pnpm setup working directory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
         with:
           version: 11.19.0
           runtime: node@22.12.0
-          package-json-file: web/package.json
+          working-directory: web
           install: false
           cache: true
           cache-dependency-path: web/pnpm-lock.yaml


### PR DESCRIPTION
Migrates pnpm/setup 2.1.0 from the deprecated package-json-file input to working-directory: web while retaining the explicit lockfile cache path and install:false contract. Local repository verification passed.